### PR TITLE
display gas estimate

### DIFF
--- a/.changeset/moody-adults-sip.md
+++ b/.changeset/moody-adults-sip.md
@@ -1,0 +1,5 @@
+---
+"@nocturne-xyz/snap": minor
+---
+
+display gas estimate to user

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,10 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "@nocturne-xyz/snap": "0.9.0"
+  },
+  "changesets": [
+    "moody-adults-sip"
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.10.0-beta.0
+
+### Minor Changes
+
+- c6385c2: display gas estimate to user
+
 ## 0.9.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -77,5 +77,20 @@
   },
   "volta": {
     "node": "18.12.1"
+  },
+  "resolutions": {
+    "@nocturne-xyz/client": "portal:../monorepo/packages/client",
+    "@nocturne-xyz/config": "portal:../monorepo/packages/config",
+    "@nocturne-xyz/core": "portal:../monorepo/packages/core",
+    "@nocturne-xyz/crypto": "portal:../monorepo/packages/crypto",
+    "@nocturne-xyz/frontend-sdk": "portal:../monorepo/packages/frontend-sdk",
+    "@nocturne-xyz/idb-kv-store": "portal:../monorepo/packages/idb-kv-store",
+    "@nocturne-xyz/local-prover": "portal:../monorepo/packages/local-prover",
+    "@nocturne-xyz/offchain-utils": "portal:../monorepo/packages/offchain-utils",
+    "@nocturne-xyz/op-request-plugins": "portal:../monorepo/packages/op-request-plugins",
+    "@nocturne-xyz/persistent-log": "portal:../monorepo/packages/persistent-log",
+    "@nocturne-xyz/hasura-sync-adapters": "portal:../monorepo/sync/hasura-sync-adapters",
+    "@nocturne-xyz/rpc-sync-adapters": "portal:../monorepo/sync/rpc-sync-adapters",
+    "@nocturne-xyz/subgraph-sync-adapters": "portal:../monorepo/sync/subgraph-sync-adapters"
   }
 }

--- a/package.json
+++ b/package.json
@@ -77,20 +77,5 @@
   },
   "volta": {
     "node": "18.12.1"
-  },
-  "resolutions": {
-    "@nocturne-xyz/client": "portal:../monorepo/packages/client",
-    "@nocturne-xyz/config": "portal:../monorepo/packages/config",
-    "@nocturne-xyz/core": "portal:../monorepo/packages/core",
-    "@nocturne-xyz/crypto": "portal:../monorepo/packages/crypto",
-    "@nocturne-xyz/frontend-sdk": "portal:../monorepo/packages/frontend-sdk",
-    "@nocturne-xyz/idb-kv-store": "portal:../monorepo/packages/idb-kv-store",
-    "@nocturne-xyz/local-prover": "portal:../monorepo/packages/local-prover",
-    "@nocturne-xyz/offchain-utils": "portal:../monorepo/packages/offchain-utils",
-    "@nocturne-xyz/op-request-plugins": "portal:../monorepo/packages/op-request-plugins",
-    "@nocturne-xyz/persistent-log": "portal:../monorepo/packages/persistent-log",
-    "@nocturne-xyz/hasura-sync-adapters": "portal:../monorepo/sync/hasura-sync-adapters",
-    "@nocturne-xyz/rpc-sync-adapters": "portal:../monorepo/sync/rpc-sync-adapters",
-    "@nocturne-xyz/subgraph-sync-adapters": "portal:../monorepo/sync/subgraph-sync-adapters"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nocturne-xyz/snap",
-  "version": "0.9.0",
+  "version": "0.10.0-beta.0",
   "description": "Nocturne Snap",
   "license": "(MIT-0 OR Apache-2.0)",
   "main": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
   },
   "dependencies": {
     "@metamask/snaps-ui": "^0.32.2",
-    "@nocturne-xyz/client": "^3.1.0",
-    "@nocturne-xyz/config": "^1.5.0",
-    "@nocturne-xyz/core": "^3.1.1",
-    "@nocturne-xyz/crypto": "^0.3.0",
+    "@nocturne-xyz/client": "^3.1.3-beta.0",
+    "@nocturne-xyz/config": "^1.7.0-beta.0",
+    "@nocturne-xyz/core": "^3.1.2-beta.0",
+    "@nocturne-xyz/crypto": "^0.4.0-beta.0",
     "bigint-json-serialization": "^1.0.1",
     "buffer": "^6.0.3",
     "superstruct": "^1.0.3"

--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -3,7 +3,7 @@
   "description": "Nocturne Snap",
   "proposedName": "Nocturne Snap",
   "source": {
-    "shasum": "fj6Pin8msz9+LKjzipdn+9tITStTsR1McVvs0tUlPV0=",
+    "shasum": "1iCy6+dv/ZNYeyjdFpnsgik5pglJeeougKgmcU41Xzg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -3,7 +3,7 @@
   "description": "Nocturne Snap",
   "proposedName": "Nocturne Snap",
   "source": {
-    "shasum": "KmnIzT66SC5xSBAsy+khv0Arg0IZk7pEdhbt4mnHZZc=",
+    "shasum": "qEgjpcd4RuMuoc3+BNUsCyNjR3POLjbNsY0QfUcVNPs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -3,7 +3,7 @@
   "description": "Nocturne Snap",
   "proposedName": "Nocturne Snap",
   "source": {
-    "shasum": "Y6Wk18P5pZ8BgZ+OH4QY2n7On0CtZAWt2iXTdFnXGck=",
+    "shasum": "fS114zWZhqn0Mvsc3utJEHidyD0FEmo4iP3gI+ulVkE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -3,7 +3,7 @@
   "description": "Nocturne Snap",
   "proposedName": "Nocturne Snap",
   "source": {
-    "shasum": "fS114zWZhqn0Mvsc3utJEHidyD0FEmo4iP3gI+ulVkE=",
+    "shasum": "Zw73RKC36CMTmgzSD5wWa0yxazNj1071ZA3KmG6I3EM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -3,7 +3,7 @@
   "description": "Nocturne Snap",
   "proposedName": "Nocturne Snap",
   "source": {
-    "shasum": "qEgjpcd4RuMuoc3+BNUsCyNjR3POLjbNsY0QfUcVNPs=",
+    "shasum": "fj6Pin8msz9+LKjzipdn+9tITStTsR1McVvs0tUlPV0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -1,9 +1,9 @@
 {
-  "version": "0.9.0",
+  "version": "0.10.0-beta.0",
   "description": "Nocturne Snap",
   "proposedName": "Nocturne Snap",
   "source": {
-    "shasum": "1iCy6+dv/ZNYeyjdFpnsgik5pglJeeougKgmcU41Xzg=",
+    "shasum": "1aG0NvMOKUwvVBc6pDwYJZPzbj7rdTevmE2pnJjxHW0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -3,7 +3,7 @@
   "description": "Nocturne Snap",
   "proposedName": "Nocturne Snap",
   "source": {
-    "shasum": "Zw73RKC36CMTmgzSD5wWa0yxazNj1071ZA3KmG6I3EM=",
+    "shasum": "KmnIzT66SC5xSBAsy+khv0Arg0IZk7pEdhbt4mnHZZc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,9 +197,7 @@ async function handleRpcRequest({
         metadata ?? { items: [] },
         (await configThunk()).erc20s,
         AssetTrait.decode(op.encodedGasAsset).assetAddr,
-
-        // TODO swtich to `op.gasEstimate` once core is bumped
-        op.gasAssetRefundThreshold
+        op.gasEstimate
       );
       // Confirm spend sig auth
       const opConfirmRes = await snap.request({

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,7 +197,7 @@ async function handleRpcRequest({
         metadata ?? { items: [] },
         (await configThunk()).erc20s,
         AssetTrait.decode(op.encodedGasAsset).assetAddr,
-        op.gasEstimate
+        op.gasFeeEstimate
       );
       // Confirm spend sig auth
       const opConfirmRes = await snap.request({

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
 } from "@nocturne-xyz/client";
 import { loadNocturneConfigBuiltin } from "@nocturne-xyz/config";
 import {
+  AssetTrait,
   NocturneSigner,
   computeCanonAddrRegistryEntryDigest,
   thunk,
@@ -194,7 +195,11 @@ async function handleRpcRequest({
       const { op, metadata } = request.params;
       const content = makeSignOperationContent(
         metadata ?? { items: [] },
-        (await configThunk()).erc20s
+        (await configThunk()).erc20s,
+        AssetTrait.decode(op.encodedGasAsset).assetAddr,
+
+        // TODO swtich to `op.gasEstimate` once core is bumped
+        op.gasAssetRefundThreshold
       );
       // Confirm spend sig auth
       const opConfirmRes = await snap.request({

--- a/src/utils/display.ts
+++ b/src/utils/display.ts
@@ -37,7 +37,7 @@ const makeFinalContent = (
       ...item.messages.map((m) => {
         const safeText = m.replace(NEWLINE_AND_CARRIAGE_RETURN_REGEX, ""); // Strip newlines and carriage returns to avoid injected malicious formatting
         return text(safeText);
-      })
+      }),
     ];
   });
   return panel(formattedItems);
@@ -50,7 +50,7 @@ export const makeSignCanonAddrRegistryEntryContent = (
   const messages = [
     `Registering your canonical address gives your Ethereum account an address with which you
       receive private payments.`,
-    `Your connected Ethereum address: **${entry.ethAddress}**`
+    `Your connected Ethereum address: **${entry.ethAddress}**`,
   ];
 
   return makeFinalContent([{ heading, messages }]);
@@ -67,7 +67,7 @@ export const makeSignOperationContent = (
       NEWLINE_AND_CARRIAGE_RETURN_REGEX,
       ""
     ),
-    messages: []
+    messages: [],
   };
 
   const actionItems = opMetadata.items.map((item) => {
@@ -84,7 +84,7 @@ export const makeSignOperationContent = (
         const {
           amount: amountSmallestUnits,
           recipientAddress,
-          erc20Address
+          erc20Address,
         } = item;
         const ticker = lookupTickerByAddress(erc20Address, erc20s);
         const displayAmount = formatUnits(amountSmallestUnits);
@@ -117,7 +117,7 @@ export const makeSignOperationContent = (
           tokenOut,
           maxSlippageBps,
           exactQuoteWei,
-          minimumAmountOutWei
+          minimumAmountOutWei,
         } = item;
         const tickerIn = lookupTickerByAddress(tokenIn, erc20s);
         const tickerOut = lookupTickerByAddress(tokenOut, erc20s);
@@ -158,7 +158,7 @@ export const makeSignOperationContent = (
       heading,
       messages: messages.map(
         (m) => m.replace(NEWLINE_AND_CARRIAGE_RETURN_REGEX, "") // Strip newlines and carriage returns
-      )
+      ),
     };
   });
 
@@ -186,7 +186,7 @@ export const makeSignOperationContent = (
     heading: gasItemHeader,
     messages: gasItemMessages.map((m) =>
       m.replace(NEWLINE_AND_CARRIAGE_RETURN_REGEX, "")
-    )
+    ),
   };
 
   return makeFinalContent([headItem, ...actionItems, gasItem]);

--- a/src/utils/display.ts
+++ b/src/utils/display.ts
@@ -31,23 +31,13 @@ const makeFinalContent = (
   items: { heading: string; messages: string[] }[]
 ): Panel => {
   const formattedItems = items.flatMap((item, i) => {
-    if (i === 0) {
-      return [
-        heading(item.heading),
-        ...item.messages.map((m) => {
-          const safeText = m.replace(NEWLINE_AND_CARRIAGE_RETURN_REGEX, ""); // Strip newlines and carriage returns to avoid injected malicious formatting
-          return text(safeText);
-        }),
-      ];
-    }
-
     return [
-      divider(),
+      ...(i > 0 ? [divider()] : []),
       heading(item.heading),
       ...item.messages.map((m) => {
         const safeText = m.replace(NEWLINE_AND_CARRIAGE_RETURN_REGEX, ""); // Strip newlines and carriage returns to avoid injected malicious formatting
         return text(safeText);
-      }),
+      })
     ];
   });
   return panel(formattedItems);
@@ -60,7 +50,7 @@ export const makeSignCanonAddrRegistryEntryContent = (
   const messages = [
     `Registering your canonical address gives your Ethereum account an address with which you
       receive private payments.`,
-    `Your connected Ethereum address: **${entry.ethAddress}**`,
+    `Your connected Ethereum address: **${entry.ethAddress}**`
   ];
 
   return makeFinalContent([{ heading, messages }]);
@@ -73,11 +63,11 @@ export const makeSignOperationContent = (
   fee: bigint
 ): Panel => {
   const headItem = {
-    heading: "Confirm transaction from our Nocturne account".replace(
+    heading: "Confirm transaction from your Nocturne account".replace(
       NEWLINE_AND_CARRIAGE_RETURN_REGEX,
       ""
     ),
-    messages: [],
+    messages: []
   };
 
   const actionItems = opMetadata.items.map((item) => {
@@ -94,7 +84,7 @@ export const makeSignOperationContent = (
         const {
           amount: amountSmallestUnits,
           recipientAddress,
-          erc20Address,
+          erc20Address
         } = item;
         const ticker = lookupTickerByAddress(erc20Address, erc20s);
         const displayAmount = formatUnits(amountSmallestUnits);
@@ -127,7 +117,7 @@ export const makeSignOperationContent = (
           tokenOut,
           maxSlippageBps,
           exactQuoteWei,
-          minimumAmountOutWei,
+          minimumAmountOutWei
         } = item;
         const tickerIn = lookupTickerByAddress(tokenIn, erc20s);
         const tickerOut = lookupTickerByAddress(tokenOut, erc20s);
@@ -168,7 +158,7 @@ export const makeSignOperationContent = (
       heading,
       messages: messages.map(
         (m) => m.replace(NEWLINE_AND_CARRIAGE_RETURN_REGEX, "") // Strip newlines and carriage returns
-      ),
+      )
     };
   });
 
@@ -196,7 +186,7 @@ export const makeSignOperationContent = (
     heading: gasItemHeader,
     messages: gasItemMessages.map((m) =>
       m.replace(NEWLINE_AND_CARRIAGE_RETURN_REGEX, "")
-    ),
+    )
   };
 
   return makeFinalContent([headItem, ...actionItems, gasItem]);

--- a/src/utils/display.ts
+++ b/src/utils/display.ts
@@ -189,7 +189,7 @@ export const makeSignOperationContent = (
   }
 
   gasItemMessages.push(
-    "Note: This fee is an estimate of how much your transaction will cost. The exact cost will be paid from your Nocturne account to the bundler that relays it, and any excess will be refunded back to your Nocturne account."
+    "Note: This fee is an estimate. Any excess will be refunded back to your Nocturne account."
   );
 
   const gasItem = {

--- a/src/utils/display.ts
+++ b/src/utils/display.ts
@@ -73,7 +73,7 @@ export const makeSignOperationContent = (
   fee: bigint
 ): Panel => {
   const headItem = {
-    heading: "Confirm transaction from your Nocturne Account".replace(
+    heading: "Confirm transaction from our Nocturne account".replace(
       NEWLINE_AND_CARRIAGE_RETURN_REGEX,
       ""
     ),
@@ -99,7 +99,7 @@ export const makeSignOperationContent = (
         const ticker = lookupTickerByAddress(erc20Address, erc20s);
         const displayAmount = formatUnits(amountSmallestUnits);
 
-        heading = "ERC-20 Transfer";
+        heading = "ERC-20 transfer";
         messages.push(
           "Action: Transfer",
           `Amount: **${displayAmount}**`,
@@ -113,7 +113,7 @@ export const makeSignOperationContent = (
       case "Transfer ETH": {
         const { recipientAddress, amount: amountSmallestUnits } = item;
         const displayAmountEth = formatUnits(amountSmallestUnits);
-        heading = "ETH Transfer";
+        heading = "ETH transfer";
         messages.push(
           `Action: Send **${displayAmountEth} ETH**`,
           `Recipient Address: ${recipientAddress}`
@@ -172,19 +172,19 @@ export const makeSignOperationContent = (
     };
   });
 
-  const gasItemHeader = "Gas Compensation";
+  const gasItemHeader = "Gas compensation";
   const gasItemMessages = [];
   const gasAssetTicker = lookupTickerByAddress(gasAssetContractAddr, erc20s);
   if (!gasAssetTicker) {
     gasItemMessages.push(
-      `Gas Fee: **${formatUnits(
+      `Gas fee: **${formatUnits(
         fee
       )} of unrecognized token (${gasAssetContractAddr})**`
     );
   } else {
     const decimals = erc20s.get(gasAssetTicker)!.precision;
     gasItemMessages.push(
-      `Gas Fee: **${formatUnits(fee, decimals)} ${gasAssetTicker}**`
+      `Gas fee: **${formatUnits(fee, decimals)} ${gasAssetTicker}**`
     );
   }
 

--- a/src/utils/display.ts
+++ b/src/utils/display.ts
@@ -99,7 +99,7 @@ export const makeSignOperationContent = (
         const ticker = lookupTickerByAddress(erc20Address, erc20s);
         const displayAmount = formatUnits(amountSmallestUnits);
 
-        heading = "ERC-20 transfer";
+        heading = "ERC-20 Transfer";
         messages.push(
           "Action: Transfer",
           `Amount: **${displayAmount}**`,
@@ -113,7 +113,7 @@ export const makeSignOperationContent = (
       case "Transfer ETH": {
         const { recipientAddress, amount: amountSmallestUnits } = item;
         const displayAmountEth = formatUnits(amountSmallestUnits);
-        heading = "ETH transfer";
+        heading = "ETH Transfer";
         messages.push(
           `Action: Send **${displayAmountEth} ETH**`,
           `Recipient Address: ${recipientAddress}`
@@ -172,19 +172,19 @@ export const makeSignOperationContent = (
     };
   });
 
-  const gasItemHeader = "Gas compensation";
+  const gasItemHeader = "Gas Compensation";
   const gasItemMessages = [];
   const gasAssetTicker = lookupTickerByAddress(gasAssetContractAddr, erc20s);
   if (!gasAssetTicker) {
     gasItemMessages.push(
-      `Gas fee: **${formatUnits(
+      `Gas Fee: **${formatUnits(
         fee
       )} of unrecognized token (${gasAssetContractAddr})**`
     );
   } else {
     const decimals = erc20s.get(gasAssetTicker)!.precision;
     gasItemMessages.push(
-      `Gas fee: **${formatUnits(fee, decimals)} ${gasAssetTicker}**`
+      `Gas Fee: **${formatUnits(fee, decimals)} ${gasAssetTicker}**`
     );
   }
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -13,7 +13,7 @@ import {
 
 export const UndefinedType = define(
   "Undefined",
-  (value) => value === undefined
+  (value) => value === undefined,
 );
 
 const isDataHexString32 = (value: any) =>
@@ -182,6 +182,7 @@ const UniswapV3SwapActionMetadataType = object({
   maxSlippageBps: number(),
   exactQuoteWei: bigint(),
   minimumAmountOutWei: bigint(),
+  gasFeeEstimate: bigint(),
 });
 
 const ActionMetadataType = union([

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -142,7 +142,7 @@ const PreSignOperationType = object({
   deadline: bigint(),
   atomicActions: boolean(),
   joinSplits: array(PreSignJoinSplitType),
-  gasEstimate: bigint(),
+  gasFeeEstimate: bigint(),
 });
 
 const ConfidentialPaymentMetadataType = object({

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -13,7 +13,7 @@ import {
 
 export const UndefinedType = define(
   "Undefined",
-  (value) => value === undefined,
+  (value) => value === undefined
 );
 
 const isDataHexString32 = (value: any) =>

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -142,6 +142,7 @@ const PreSignOperationType = object({
   deadline: bigint(),
   atomicActions: boolean(),
   joinSplits: array(PreSignJoinSplitType),
+  gasEstimate: bigint(),
 });
 
 const ConfidentialPaymentMetadataType = object({

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -182,7 +182,6 @@ const UniswapV3SwapActionMetadataType = object({
   maxSlippageBps: number(),
   exactQuoteWei: bigint(),
   minimumAmountOutWei: bigint(),
-  gasFeeEstimate: bigint(),
 });
 
 const ActionMetadataType = union([

--- a/test/validation.ts
+++ b/test/validation.ts
@@ -222,6 +222,7 @@ it("validates SignOperationParams", () => {
           },
         },
       ],
+      gasEstimate: 1n,
     },
     metadata: {
       items: [
@@ -234,7 +235,6 @@ it("validates SignOperationParams", () => {
           maxSlippageBps: 50,
           exactQuoteWei: 1234n,
           minimumAmountOutWei: 1234n,
-          gasFeeEstimate: 1n,
         },
       ],
     },

--- a/test/validation.ts
+++ b/test/validation.ts
@@ -234,6 +234,7 @@ it("validates SignOperationParams", () => {
           maxSlippageBps: 50,
           exactQuoteWei: 1234n,
           minimumAmountOutWei: 1234n,
+          gasFeeEstimate: 1n,
         },
       ],
     },

--- a/test/validation.ts
+++ b/test/validation.ts
@@ -222,7 +222,7 @@ it("validates SignOperationParams", () => {
           },
         },
       ],
-      gasEstimate: 1n,
+      gasFeeEstimate: 1n,
     },
     metadata: {
       items: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2769,31 +2769,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nocturne-xyz/client@portal:../monorepo/packages/client::locator=%40nocturne-xyz%2Fsnap%40workspace%3A.":
-  version: 0.0.0-use.local
-  resolution: "@nocturne-xyz/client@portal:../monorepo/packages/client::locator=%40nocturne-xyz%2Fsnap%40workspace%3A."
+"@nocturne-xyz/client@npm:^3.1.0":
+  version: 3.1.2
+  resolution: "@nocturne-xyz/client@npm:3.1.2"
   dependencies:
-    "@nocturne-xyz/config": "workspace:^"
+    "@nocturne-xyz/config": ^1.6.0
     "@nocturne-xyz/contracts": ^3.0.0
-    "@nocturne-xyz/core": "workspace:^"
-    "@nocturne-xyz/crypto": "workspace:^"
+    "@nocturne-xyz/core": ^3.1.2
+    "@nocturne-xyz/crypto": ^0.3.0
     async-mutex: ^0.4.0
     big-integer: ^1.6.42
     bigint-json-serialization: ^1.0.1
     ethers: ^5.7.2
     js-sha256: ^0.9.0
+  checksum: 66b936d4b469d89fbf4e81487cbb673020f444cf1960946dfa79e1f2a79fdc20013f36810e396facf8b71cbf269e68f1e83d3ef02bd7852776071b14a33fe534
   languageName: node
-  linkType: soft
+  linkType: hard
 
-"@nocturne-xyz/config@portal:../monorepo/packages/config::locator=%40nocturne-xyz%2Fsnap%40workspace%3A.":
-  version: 0.0.0-use.local
-  resolution: "@nocturne-xyz/config@portal:../monorepo/packages/config::locator=%40nocturne-xyz%2Fsnap%40workspace%3A."
+"@nocturne-xyz/config@npm:^1.5.0, @nocturne-xyz/config@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "@nocturne-xyz/config@npm:1.6.0"
   dependencies:
     big-integer: ^1.6.42
     bigint-json-serialization: ^1.0.1
     ethers: ^5.7.2
+  checksum: 735997ae13f106b4aefb30df9564ead7ebd6292185b7740c516843441c14075eb2aa59f2bc3d79185ec994955e57f21ae5e4639c0e57aac75365a11fd1a9ffce
   languageName: node
-  linkType: soft
+  linkType: hard
 
 "@nocturne-xyz/contracts@npm:^3.0.0":
   version: 3.0.0
@@ -2805,12 +2807,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nocturne-xyz/core@portal:../monorepo/packages/core::locator=%40nocturne-xyz%2Fsnap%40workspace%3A.":
-  version: 0.0.0-use.local
-  resolution: "@nocturne-xyz/core@portal:../monorepo/packages/core::locator=%40nocturne-xyz%2Fsnap%40workspace%3A."
+"@nocturne-xyz/core@npm:^3.1.1, @nocturne-xyz/core@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "@nocturne-xyz/core@npm:3.1.2"
   dependencies:
     "@nocturne-xyz/contracts": ^3.0.0
-    "@nocturne-xyz/crypto": "workspace:^"
+    "@nocturne-xyz/crypto": ^0.3.0
     "@zk-kit/incremental-merkle-tree": ^1.0.0
     async-mutex: ^0.4.0
     async-retry: ^1.3.3
@@ -2820,20 +2822,22 @@ __metadata:
     js-sha256: ^0.9.0
     sorted-btree: ^1.8.1
     winston: ^3.9.0
+  checksum: 47891973e2a73f7247dc4673f20d8eb8ae0300e02082f48de61039f2b74ef2c1d2e5d32c7be0ff3040dbcc0a22a829080ad6138328672408971f9fcd4143b4ee
   languageName: node
-  linkType: soft
+  linkType: hard
 
-"@nocturne-xyz/crypto@portal:../monorepo/packages/crypto::locator=%40nocturne-xyz%2Fsnap%40workspace%3A.":
-  version: 0.0.0-use.local
-  resolution: "@nocturne-xyz/crypto@portal:../monorepo/packages/crypto::locator=%40nocturne-xyz%2Fsnap%40workspace%3A."
+"@nocturne-xyz/crypto@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@nocturne-xyz/crypto@npm:0.3.0"
   dependencies:
     "@noble/curves": ^1.2.0
     "@noble/hashes": ^1.3.1
     "@stablelib/chacha20poly1305": ^1.0.1
     bigint-json-serialization: ^1.0.1
     ethers: ^5.7.2
+  checksum: 68ffbd9b54a3ac17e926b8c1a14bcc74c8a28ec75e85a1de7fb4e039208a660ee4cafd3db9a35d427bb027e3918e8499eb83fd894d70c79ec9b5ca98b0fafa0d
   languageName: node
-  linkType: soft
+  linkType: hard
 
 "@nocturne-xyz/snap@workspace:.":
   version: 0.0.0-use.local

--- a/yarn.lock
+++ b/yarn.lock
@@ -2770,48 +2770,48 @@ __metadata:
   linkType: hard
 
 "@nocturne-xyz/client@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "@nocturne-xyz/client@npm:3.1.0"
+  version: 3.1.2
+  resolution: "@nocturne-xyz/client@npm:3.1.2"
   dependencies:
-    "@nocturne-xyz/config": ^1.5.0
-    "@nocturne-xyz/contracts": ^2.0.1
-    "@nocturne-xyz/core": ^3.1.1
+    "@nocturne-xyz/config": ^1.6.0
+    "@nocturne-xyz/contracts": ^3.0.0
+    "@nocturne-xyz/core": ^3.1.2
     "@nocturne-xyz/crypto": ^0.3.0
     async-mutex: ^0.4.0
     big-integer: ^1.6.42
     bigint-json-serialization: ^1.0.1
     ethers: ^5.7.2
     js-sha256: ^0.9.0
-  checksum: 081f1c3a9488970252a63d7d5712ee464c40ea81588652546f85b689618ef05a24afe1a479182f573c263ec0e8652d96029659dfbd3554b22e3917190b8c6ca4
+  checksum: 66b936d4b469d89fbf4e81487cbb673020f444cf1960946dfa79e1f2a79fdc20013f36810e396facf8b71cbf269e68f1e83d3ef02bd7852776071b14a33fe534
   languageName: node
   linkType: hard
 
-"@nocturne-xyz/config@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "@nocturne-xyz/config@npm:1.5.0"
+"@nocturne-xyz/config@npm:^1.5.0, @nocturne-xyz/config@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "@nocturne-xyz/config@npm:1.6.0"
   dependencies:
     big-integer: ^1.6.42
     bigint-json-serialization: ^1.0.1
     ethers: ^5.7.2
-  checksum: 58da3e1b372765c2a47e07486744e052548352488de9df24992b794756cb86b4cd58ee6c1e9e146431f1e3a33bbb5a83ad056d37d8e7ccb78b1e489133103198
+  checksum: 735997ae13f106b4aefb30df9564ead7ebd6292185b7740c516843441c14075eb2aa59f2bc3d79185ec994955e57f21ae5e4639c0e57aac75365a11fd1a9ffce
   languageName: node
   linkType: hard
 
-"@nocturne-xyz/contracts@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@nocturne-xyz/contracts@npm:2.0.1"
+"@nocturne-xyz/contracts@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@nocturne-xyz/contracts@npm:3.0.0"
   dependencies:
     "@openzeppelin/contracts": 4.9.2
     "@openzeppelin/contracts-upgradeable": 4.9.2
-  checksum: 7021031cf7e0f4af76f95b450c128ebf84a1a6b759c82198d9c0fe4fa486564644fb33839aca751e5ae577a5c33fc1a0e51867ecb3b05e600029e2a24346572d
+  checksum: 9f8d519a020f27ad4af0090d863c0c9c51125348aa51302a4dd4443fd173afd7cd089aaab18e5618a01fa907f92883dc657665e62d4d9e56217a079f43649c26
   languageName: node
   linkType: hard
 
-"@nocturne-xyz/core@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "@nocturne-xyz/core@npm:3.1.1"
+"@nocturne-xyz/core@npm:^3.1.1, @nocturne-xyz/core@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "@nocturne-xyz/core@npm:3.1.2"
   dependencies:
-    "@nocturne-xyz/contracts": ^2.0.1
+    "@nocturne-xyz/contracts": ^3.0.0
     "@nocturne-xyz/crypto": ^0.3.0
     "@zk-kit/incremental-merkle-tree": ^1.0.0
     async-mutex: ^0.4.0
@@ -2822,7 +2822,7 @@ __metadata:
     js-sha256: ^0.9.0
     sorted-btree: ^1.8.1
     winston: ^3.9.0
-  checksum: d12a1a817002f67209438fa90c2502404651184709fc349a26bef8b7a94fa5447a6bd2c091c6a08060deed6a4317859a5e0cd2ef5374da0eb37e9081fe04e5a1
+  checksum: 47891973e2a73f7247dc4673f20d8eb8ae0300e02082f48de61039f2b74ef2c1d2e5d32c7be0ff3040dbcc0a22a829080ad6138328672408971f9fcd4143b4ee
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2769,24 +2769,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nocturne-xyz/client@npm:^3.1.0":
-  version: 3.1.2
-  resolution: "@nocturne-xyz/client@npm:3.1.2"
+"@nocturne-xyz/client@npm:^3.1.3-beta.0":
+  version: 3.1.3-less-hashes
+  resolution: "@nocturne-xyz/client@npm:3.1.3-less-hashes"
   dependencies:
-    "@nocturne-xyz/config": ^1.6.0
+    "@nocturne-xyz/config": ^1.5.0
     "@nocturne-xyz/contracts": ^3.0.0
-    "@nocturne-xyz/core": ^3.1.2
-    "@nocturne-xyz/crypto": ^0.3.0
+    "@nocturne-xyz/core": ^3.1.3-less-hashes
+    "@nocturne-xyz/crypto": ^0.4.0-less-hashes
     async-mutex: ^0.4.0
     big-integer: ^1.6.42
     bigint-json-serialization: ^1.0.1
     ethers: ^5.7.2
     js-sha256: ^0.9.0
-  checksum: 66b936d4b469d89fbf4e81487cbb673020f444cf1960946dfa79e1f2a79fdc20013f36810e396facf8b71cbf269e68f1e83d3ef02bd7852776071b14a33fe534
+  checksum: 3ddce7046a7cf774049c24de6b2e9f98955b0dd7e9305ae71ff88ee887c84f890cdefd89b2574e2b019f249e8e735ce2cb06a823b062a3d8c60a89082bf614e2
   languageName: node
   linkType: hard
 
-"@nocturne-xyz/config@npm:^1.5.0, @nocturne-xyz/config@npm:^1.6.0":
+"@nocturne-xyz/config@npm:^1.5.0":
   version: 1.6.0
   resolution: "@nocturne-xyz/config@npm:1.6.0"
   dependencies:
@@ -2794,6 +2794,17 @@ __metadata:
     bigint-json-serialization: ^1.0.1
     ethers: ^5.7.2
   checksum: 735997ae13f106b4aefb30df9564ead7ebd6292185b7740c516843441c14075eb2aa59f2bc3d79185ec994955e57f21ae5e4639c0e57aac75365a11fd1a9ffce
+  languageName: node
+  linkType: hard
+
+"@nocturne-xyz/config@npm:^1.7.0-beta.0":
+  version: 1.7.0-beta.0
+  resolution: "@nocturne-xyz/config@npm:1.7.0-beta.0"
+  dependencies:
+    big-integer: ^1.6.42
+    bigint-json-serialization: ^1.0.1
+    ethers: ^5.7.2
+  checksum: 3c8fa50a4cbe6b4c8109ac22e085ab25544cc759cb66e1f576c33598ec6ab99d477c60cad51e578fbab7b6f821580b4e5ea7702cc4fc6d2d56a6ec39c010aec7
   languageName: node
   linkType: hard
 
@@ -2807,7 +2818,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nocturne-xyz/core@npm:^3.1.1, @nocturne-xyz/core@npm:^3.1.2":
+"@nocturne-xyz/core@npm:^3.1.2-beta.0":
   version: 3.1.2
   resolution: "@nocturne-xyz/core@npm:3.1.2"
   dependencies:
@@ -2826,6 +2837,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nocturne-xyz/core@npm:^3.1.3-less-hashes":
+  version: 3.1.3-tsup1
+  resolution: "@nocturne-xyz/core@npm:3.1.3-tsup1"
+  dependencies:
+    "@nocturne-xyz/contracts": ^3.0.0
+    "@nocturne-xyz/crypto": ^0.4.0-tsup1
+    "@zk-kit/incremental-merkle-tree": ^1.1.0
+    async-mutex: ^0.4.0
+    async-retry: ^1.3.3
+    big-integer: ^1.6.42
+    bigint-json-serialization: ^1.0.1
+    ethers: ^5.7.2
+    js-sha256: ^0.9.0
+    sorted-btree: ^1.8.1
+    winston: ^3.9.0
+  checksum: e8a1ef947a590fc6ec736c833e67d4b03333c1dedca42e6843963e99bae09a5fb88a77b4dd94b209a834892ec4782c9087e0813d608080ed7cd6f1c02030b3a8
+  languageName: node
+  linkType: hard
+
 "@nocturne-xyz/crypto@npm:^0.3.0":
   version: 0.3.0
   resolution: "@nocturne-xyz/crypto@npm:0.3.0"
@@ -2836,6 +2866,20 @@ __metadata:
     bigint-json-serialization: ^1.0.1
     ethers: ^5.7.2
   checksum: 68ffbd9b54a3ac17e926b8c1a14bcc74c8a28ec75e85a1de7fb4e039208a660ee4cafd3db9a35d427bb027e3918e8499eb83fd894d70c79ec9b5ca98b0fafa0d
+  languageName: node
+  linkType: hard
+
+"@nocturne-xyz/crypto@npm:^0.4.0-beta.0, @nocturne-xyz/crypto@npm:^0.4.0-less-hashes, @nocturne-xyz/crypto@npm:^0.4.0-tsup1":
+  version: 0.4.0-tsup1
+  resolution: "@nocturne-xyz/crypto@npm:0.4.0-tsup1"
+  dependencies:
+    "@noble/curves": ^1.2.0
+    "@noble/hashes": ^1.3.1
+    "@stablelib/chacha20poly1305": ^1.0.1
+    bigint-json-serialization: ^1.0.1
+    ethers: ^5.7.2
+    randombytes: ^2.1.0
+  checksum: 3f301311a2553d48dd7457e18f52db648366de33200c27c4cb0c96b3e1c7dd39e2e5dda42b226e9d19ffd58c0a89eccdad219ce049e1e666776c619c6cf16538
   languageName: node
   linkType: hard
 
@@ -2853,10 +2897,10 @@ __metadata:
     "@metamask/snaps-cli": 0.32.2
     "@metamask/snaps-types": 0.32.2
     "@metamask/snaps-ui": ^0.32.2
-    "@nocturne-xyz/client": ^3.1.0
-    "@nocturne-xyz/config": ^1.5.0
-    "@nocturne-xyz/core": ^3.1.1
-    "@nocturne-xyz/crypto": ^0.3.0
+    "@nocturne-xyz/client": ^3.1.3-beta.0
+    "@nocturne-xyz/config": ^1.7.0-beta.0
+    "@nocturne-xyz/core": ^3.1.2-beta.0
+    "@nocturne-xyz/crypto": ^0.4.0-beta.0
     "@types/chai": ^4.3.9
     "@types/mocha": ^10.0.3
     "@types/node": ^20.8.9
@@ -3423,7 +3467,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@zk-kit/incremental-merkle-tree@npm:^1.0.0":
+"@zk-kit/incremental-merkle-tree@npm:^1.0.0, @zk-kit/incremental-merkle-tree@npm:^1.1.0":
   version: 1.1.0
   resolution: "@zk-kit/incremental-merkle-tree@npm:1.1.0"
   checksum: 5f2d6dd2a4898aa75f72d5b3811ab965c369f0a51561250313849fb9a6a1163064c4887da3bea298d25e80a4bc79b3c6997edf6492a6a8fc157512bc3fcb5e23

--- a/yarn.lock
+++ b/yarn.lock
@@ -2769,33 +2769,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nocturne-xyz/client@npm:^3.1.0":
-  version: 3.1.2
-  resolution: "@nocturne-xyz/client@npm:3.1.2"
+"@nocturne-xyz/client@portal:../monorepo/packages/client::locator=%40nocturne-xyz%2Fsnap%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@nocturne-xyz/client@portal:../monorepo/packages/client::locator=%40nocturne-xyz%2Fsnap%40workspace%3A."
   dependencies:
-    "@nocturne-xyz/config": ^1.6.0
+    "@nocturne-xyz/config": "workspace:^"
     "@nocturne-xyz/contracts": ^3.0.0
-    "@nocturne-xyz/core": ^3.1.2
-    "@nocturne-xyz/crypto": ^0.3.0
+    "@nocturne-xyz/core": "workspace:^"
+    "@nocturne-xyz/crypto": "workspace:^"
     async-mutex: ^0.4.0
     big-integer: ^1.6.42
     bigint-json-serialization: ^1.0.1
     ethers: ^5.7.2
     js-sha256: ^0.9.0
-  checksum: 66b936d4b469d89fbf4e81487cbb673020f444cf1960946dfa79e1f2a79fdc20013f36810e396facf8b71cbf269e68f1e83d3ef02bd7852776071b14a33fe534
   languageName: node
-  linkType: hard
+  linkType: soft
 
-"@nocturne-xyz/config@npm:^1.5.0, @nocturne-xyz/config@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "@nocturne-xyz/config@npm:1.6.0"
+"@nocturne-xyz/config@portal:../monorepo/packages/config::locator=%40nocturne-xyz%2Fsnap%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@nocturne-xyz/config@portal:../monorepo/packages/config::locator=%40nocturne-xyz%2Fsnap%40workspace%3A."
   dependencies:
     big-integer: ^1.6.42
     bigint-json-serialization: ^1.0.1
     ethers: ^5.7.2
-  checksum: 735997ae13f106b4aefb30df9564ead7ebd6292185b7740c516843441c14075eb2aa59f2bc3d79185ec994955e57f21ae5e4639c0e57aac75365a11fd1a9ffce
   languageName: node
-  linkType: hard
+  linkType: soft
 
 "@nocturne-xyz/contracts@npm:^3.0.0":
   version: 3.0.0
@@ -2807,12 +2805,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nocturne-xyz/core@npm:^3.1.1, @nocturne-xyz/core@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "@nocturne-xyz/core@npm:3.1.2"
+"@nocturne-xyz/core@portal:../monorepo/packages/core::locator=%40nocturne-xyz%2Fsnap%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@nocturne-xyz/core@portal:../monorepo/packages/core::locator=%40nocturne-xyz%2Fsnap%40workspace%3A."
   dependencies:
     "@nocturne-xyz/contracts": ^3.0.0
-    "@nocturne-xyz/crypto": ^0.3.0
+    "@nocturne-xyz/crypto": "workspace:^"
     "@zk-kit/incremental-merkle-tree": ^1.0.0
     async-mutex: ^0.4.0
     async-retry: ^1.3.3
@@ -2822,22 +2820,20 @@ __metadata:
     js-sha256: ^0.9.0
     sorted-btree: ^1.8.1
     winston: ^3.9.0
-  checksum: 47891973e2a73f7247dc4673f20d8eb8ae0300e02082f48de61039f2b74ef2c1d2e5d32c7be0ff3040dbcc0a22a829080ad6138328672408971f9fcd4143b4ee
   languageName: node
-  linkType: hard
+  linkType: soft
 
-"@nocturne-xyz/crypto@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@nocturne-xyz/crypto@npm:0.3.0"
+"@nocturne-xyz/crypto@portal:../monorepo/packages/crypto::locator=%40nocturne-xyz%2Fsnap%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@nocturne-xyz/crypto@portal:../monorepo/packages/crypto::locator=%40nocturne-xyz%2Fsnap%40workspace%3A."
   dependencies:
     "@noble/curves": ^1.2.0
     "@noble/hashes": ^1.3.1
     "@stablelib/chacha20poly1305": ^1.0.1
     bigint-json-serialization: ^1.0.1
     ethers: ^5.7.2
-  checksum: 68ffbd9b54a3ac17e926b8c1a14bcc74c8a28ec75e85a1de7fb4e039208a660ee4cafd3db9a35d427bb027e3918e8499eb83fd894d70c79ec9b5ca98b0fafa0d
   languageName: node
-  linkType: hard
+  linkType: soft
 
 "@nocturne-xyz/snap@workspace:.":
   version: 0.0.0-use.local


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.
-->

## Motivation

User currently has no idea how much gas they're paying for their ops

## Solution

Display it in the snap. To do this, we add a `gasEstimate` field to `PreSignOperation` (see ___) and then add an extra item listing the gas fee and an explanation to the displayed content on the sign operation popup. Also tweaked the display a bit because the current one looked weird now that there were multiple items:

<img width="832" alt="Screenshot 2023-11-10 at 8 22 52 AM" src="https://github.com/nocturne-xyz/snap/assets/21142281/9b967dbb-6c02-422f-b99f-31b5fc82f627">

Note that this PR is coupled with https://github.com/nocturne-xyz/monorepo/pull/587, and therefore it will not build until that is merged and published.


## Proof

See above image. Everything still works when linked to monorepo.

## PR Checklist

- [ ] added tests
- [ ] updated documentation
- [x] added changeset if necessary
- [x] tested in dev/testnet
- [x] tested site with snap (we haven't automated this yet)
- [ ] re-built & tested circuits if any of them changed
- [ ] updated contracts storage layout (if contracts were updated)
